### PR TITLE
Handle help text printed by modulefiles

### DIFF
--- a/modulecmd.py
+++ b/modulecmd.py
@@ -293,6 +293,7 @@ class Modulecmd:
         traceback.print_exc()
     if out: 
       if cmdtype not in noout_cmds:
+	out = '\n'.join([line for line in out.split('\n') if 'os.environ' in line])
         if self.verbose:
           print "Calling eval on %s" % out
         exec(out)


### PR DESCRIPTION
If the modulefiles at your site print a helpful message, e.g.
"Loading [module] with path [path]"
then module.load('module') will fail. This fixes that problem for me. I do not know if there are cases where things that are not os.environ calls might be part of the command. If that is the case, then a more elaborate fix would be needed.